### PR TITLE
Fix error handling in web feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl TreeSitter {
             } else {
                 Ok(property)
             }
-        })?;
+        }).lift_error()?;
 
         // Call `init` from `web-tree-sitter` to initialize emscripten
         let init = Reflect::get(&tree_sitter, &"init".into())


### PR DESCRIPTION
Compilation fails when compiling the web features:

```
cargo build --target wasm32-unknown-unknown --no-default-features --features web
   Compiling web-tree-sitter-sg v1.3.0 (/home/gboutry/Documents/projects/web-tree-sitter-sg)
error[E0277]: the trait bound `wasm_bindgen::JsValue: std::error::Error` is not satisfied
  --> src/lib.rs:85:11
   |
85 |         })?;
   |           ^ the trait `std::error::Error` is not implemented for `wasm_bindgen::JsValue`
   |
   = help: the following other types implement trait `FromResidual<R>`:
             <Result<T, F> as FromResidual<Result<Infallible, E>>>
             <Result<T, F> as FromResidual<Yeet<E>>>
   = note: required for `wasm_bindgen::JsError` to implement `From<wasm_bindgen::JsValue>`
   = note: required for `Result<(), wasm_bindgen::JsError>` to implement `FromResidual<Result<Infallible, wasm_bindgen::JsValue>>`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `web-tree-sitter-sg` due to previous error
```